### PR TITLE
Add extra 'div' to all wikipedia pages to be scraped

### DIFF
--- a/_source/2016-08-21-gapMedal.Rmd
+++ b/_source/2016-08-21-gapMedal.Rmd
@@ -66,7 +66,7 @@ scrape_medaltab <- function(year) {
   tableNumber <- ifelse(year %in% c(1960,1984,1992,1996,2000,2004,2008,2012,2016), 2,1) #table number depends on year
   medals <- gsub("1960",year,base_url) %>%
     read_html() %>%
-    html_nodes(xpath=paste0("//*[@id=\"mw-content-text\"]/table[",tableNumber,"]")) %>%
+    html_nodes(xpath=paste0("//*[@id=\"mw-content-text\"]/div//table[",tableNumber,"]")) %>%
     html_table(fill=TRUE) #%>% .[[1]]
   medals <- medals[[1]]
   #Sometimes the nation is called NOC, and "Rank" is also " Rank " once


### PR DESCRIPTION
I was trying to re-run your code to scrape the medals data and join with the gapminder data as I thought it might make a good example dataset for an R course.

However, I noticed that the scraping wasn't working. I guess the wikipedia schema must have changed? Anyway I think this should now work.

